### PR TITLE
refactor: migrate macros to smallvec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,6 +663,7 @@ dependencies = [
  "notify-debouncer-mini",
  "serde",
  "serde_yaml",
+ "smallvec",
  "thiserror",
 ]
 
@@ -688,6 +689,7 @@ dependencies = [
  "log",
  "lunchctl",
  "nsworkspace",
+ "smallvec",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,9 @@ sdl2 = "0.37"
 # Keyboard bindings
 enigo = "0.6.0"
 
-# Fast hashmaps
+# Fast data types
 ahash = "0.8"
+smallvec = "1.15"
 
 # Concurrent channels
 crossbeam-channel = "0.5"

--- a/crates/gamacros-workspace/Cargo.toml
+++ b/crates/gamacros-workspace/Cargo.toml
@@ -19,6 +19,7 @@ thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_yaml = { workspace = true }
 ahash = { workspace = true, features = ["serde"] }
+smallvec = { workspace = true }
 notify = { workspace = true }
 notify-debouncer-mini = { workspace = true }
 

--- a/crates/gamacros-workspace/resources/gc_profile.yaml
+++ b/crates/gamacros-workspace/resources/gc_profile.yaml
@@ -10,6 +10,12 @@ controllers:
       b: a
       x: y
       y: x
+  # DualSense
+  - vid: 0x045e
+    pid: 0x0039
+    remap:
+      l2: r2
+      r2: l2
 
 # Shell to run for shell actions.
 shell: /bin/zsh
@@ -38,30 +44,27 @@ rules:
   # Common rules for all apps.
   common:
     buttons:
-      l1:
+      b:
         vibrate: 100
         keystroke: cmd
-      b:
-        keystroke: enter
       a:
-        keystroke: escape
+        keystroke: cmd+shift+i+q
       r1:
-        keystroke: backspace
-      l2+r2:
+        shell: echo "r1" | pbcopy
+      l2+r2+l1:
         vibrate: 100
         macros:
           - cmd+a
           - backspace
+    sticks:
+      right:
+        mode: arrows
+      left:
+        mode: volume
+
 
   $ide | $browser:
     buttons:
-      y:
-        shell: |
-          echo "$"
-      select:
-        keystroke: cmd+dot
-      start:
-        keystroke: cmd+i
       dpad_up:
         keystroke: arrow_up
       dpad_left:
@@ -76,3 +79,4 @@ rules:
         max_speed_px_s: 1600
       left:
         mode: scroll
+

--- a/crates/gamacros-workspace/src/lib.rs
+++ b/crates/gamacros-workspace/src/lib.rs
@@ -15,7 +15,7 @@ pub use profile_parse::parse_profile;
 pub use profile::{
     Profile, ButtonAction, ButtonRule, ControllerSettings, ControllerSettingsMap,
     StickRules, ArrowsParams, Axis, MouseParams, ScrollParams, StepperParams,
-    StickMode, StickSide, AppRules, RuleMap, ButtonRules,
+    StickMode, StickSide, AppRules, RuleMap, ButtonRules, Macros,
 };
 // pub use profile::resolve_profile;
 pub use workspace::Workspace;

--- a/crates/gamacros-workspace/src/profile.rs
+++ b/crates/gamacros-workspace/src/profile.rs
@@ -4,6 +4,7 @@ use ahash::{AHashMap, AHashSet};
 
 use gamacros_control::KeyCombo;
 use gamacros_gamepad::Button;
+use smallvec::SmallVec;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -62,11 +63,14 @@ pub type RuleMap = AHashMap<BundleId, AppRules>;
 /// A set of rules to handle app settings for an app.
 pub type ControllerSettingsMap = AHashMap<ControllerId, ControllerSettings>;
 
+/// A set of macros.
+pub type Macros = SmallVec<[KeyCombo; 4]>;
+
 /// A action for a gamepad button.
 #[derive(Debug, Clone)]
 pub enum ButtonAction {
     Keystroke(Arc<KeyCombo>),
-    Macros(Arc<Vec<KeyCombo>>),
+    Macros(Arc<Macros>),
     Shell(String),
 }
 

--- a/crates/gamacros-workspace/src/v1/combo.rs
+++ b/crates/gamacros-workspace/src/v1/combo.rs
@@ -1,0 +1,201 @@
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum SequenceErrorKind {
+    LeadingOperator,
+    TrailingOperator,
+    DoubleOperator,
+    MissingOperatorBetweenTerms,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct SequenceError<'a> {
+    pub rest: &'a str,
+    pub kind: SequenceErrorKind,
+}
+
+/// Tokenize with a custom one-character delimiter. Returns either the next
+/// term (non-empty slice without surrounding whitespace) or the delimiter
+/// itself as a one-character slice, plus the remaining input.
+pub(crate) fn next_token_with(input: &str, delim: char) -> Option<(&str, &str)> {
+    // Skip leading whitespace
+    let input = input.trim_start();
+    if input.is_empty() {
+        return None;
+    }
+
+    // If the next character is the delimiter, return it as a separate token
+    let chars = input.char_indices();
+    if let Some((_, first_ch)) = chars.clone().next() {
+        if first_ch == delim {
+            let len = first_ch.len_utf8();
+            return Some((&input[..len], &input[len..]));
+        }
+    }
+
+    // Otherwise, read until next whitespace or delimiter
+    for (i, ch) in chars {
+        if ch == delim {
+            return Some((&input[..i], &input[i..]));
+        }
+        if ch.is_whitespace() {
+            // Trim all subsequent whitespace in the rest for stable tokenization
+            let rest = input[i..].trim_start();
+            return Some((&input[..i], rest));
+        }
+    }
+
+    Some((input, ""))
+}
+
+/// Parse a sequence of terms separated by the given delimiter.
+/// Enforces the following rules:
+/// - No leading delimiter
+/// - No consecutive delimiters
+/// - No consecutive terms without a delimiter between them
+/// - No trailing delimiter
+///
+/// Returns the list of term slices (without delimiters or surrounding spaces).
+pub(crate) fn parse_terms_with_delim<'a>(
+    mut input: &'a str,
+    delim: char,
+) -> Result<Vec<&'a str>, SequenceError<'a>> {
+    #[derive(PartialEq, Eq, Clone, Copy)]
+    enum LastTokenKind {
+        None,
+        Term,
+        Operator,
+    }
+
+    let mut terms: Vec<&'a str> = Vec::new();
+    let mut last = LastTokenKind::None;
+
+    while let Some((token, rest)) = next_token_with(input, delim) {
+        input = rest;
+
+        let is_operator = token.chars().count() == 1 && token.starts_with(delim);
+        if is_operator {
+            match last {
+                LastTokenKind::None => {
+                    return Err(SequenceError {
+                        rest: input,
+                        kind: SequenceErrorKind::LeadingOperator,
+                    });
+                }
+                LastTokenKind::Operator => {
+                    return Err(SequenceError {
+                        rest: input,
+                        kind: SequenceErrorKind::DoubleOperator,
+                    });
+                }
+                LastTokenKind::Term => {
+                    last = LastTokenKind::Operator;
+                }
+            }
+        } else {
+            match last {
+                LastTokenKind::Term => {
+                    // Two terms in a row without a delimiter
+                    return Err(SequenceError {
+                        rest: input,
+                        kind: SequenceErrorKind::MissingOperatorBetweenTerms,
+                    });
+                }
+                _ => {
+                    terms.push(token);
+                    last = LastTokenKind::Term;
+                }
+            }
+        }
+    }
+
+    if last == LastTokenKind::Operator {
+        return Err(SequenceError {
+            rest: "",
+            kind: SequenceErrorKind::TrailingOperator,
+        });
+    }
+
+    Ok(terms)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tokenizer_with_delim_splits_on_space_and_preserves_rest() {
+        let input = "$ide | com.apple.Safari";
+        let (tok, rest) =
+            next_token_with(input, '|').expect("should find first token");
+        assert_eq!(tok, "$ide");
+        assert_eq!(rest, "| com.apple.Safari");
+    }
+
+    #[test]
+    fn tokenizer_with_delim_handles_single_token_without_spaces() {
+        let input = "com.apple.Safari";
+        let (tok, rest) =
+            next_token_with(input, '|').expect("should return single token");
+        assert_eq!(tok, "com.apple.Safari");
+        assert_eq!(rest, "");
+    }
+
+    #[test]
+    fn tokenizer_with_delim_splits_on_pipe_without_spaces() {
+        let input = "$ide|com.apple.Safari";
+        let (tok, rest) =
+            next_token_with(input, '|').expect("should find first token");
+        assert_eq!(tok, "$ide");
+        assert_eq!(rest, "|com.apple.Safari");
+    }
+
+    #[test]
+    fn tokenizer_with_delim_skips_multiple_spaces() {
+        let input = "$ide   |   com.apple.Safari";
+        let (tok, rest) =
+            next_token_with(input, '|').expect("should find first token");
+        assert_eq!(tok, "$ide");
+        assert_eq!(rest, "|   com.apple.Safari");
+    }
+
+    #[test]
+    fn parse_terms_accepts_valid_sequence() {
+        let terms =
+            parse_terms_with_delim("$ide | com.apple.Safari | $browser", '|')
+                .expect("parser should accept valid selector");
+        assert_eq!(terms, vec!["$ide", "com.apple.Safari", "$browser"]);
+    }
+
+    #[test]
+    fn parse_terms_rejects_consecutive_operators() {
+        let err =
+            parse_terms_with_delim("$ide | | com.apple.Safari", '|').unwrap_err();
+        assert_eq!(err.kind, SequenceErrorKind::DoubleOperator);
+    }
+
+    #[test]
+    fn parse_terms_requires_operator_between_terms() {
+        let err = parse_terms_with_delim("$ide com.apple.Safari", '|').unwrap_err();
+        assert_eq!(err.kind, SequenceErrorKind::MissingOperatorBetweenTerms);
+    }
+
+    #[test]
+    fn parse_terms_rejects_leading_operator() {
+        let err =
+            parse_terms_with_delim("| $ide | com.apple.Safari", '|').unwrap_err();
+        assert_eq!(err.kind, SequenceErrorKind::LeadingOperator);
+    }
+
+    #[test]
+    fn parse_terms_rejects_trailing_operator() {
+        let err =
+            parse_terms_with_delim("$ide | com.apple.Safari |", '|').unwrap_err();
+        assert_eq!(err.kind, SequenceErrorKind::TrailingOperator);
+    }
+
+    #[test]
+    fn parse_terms_accepts_adjacent_delims_without_spaces() {
+        let terms = parse_terms_with_delim("$ide|$browser|com.apple.Safari", '|')
+            .expect("parser should accept adjacent pipes");
+        assert_eq!(terms, vec!["$ide", "$browser", "com.apple.Safari"]);
+    }
+}

--- a/crates/gamacros-workspace/src/v1/mod.rs
+++ b/crates/gamacros-workspace/src/v1/mod.rs
@@ -2,6 +2,7 @@ mod strings;
 mod parse;
 mod profile;
 mod selector;
+mod combo;
 
 use thiserror::Error;
 

--- a/crates/gamacros-workspace/src/v1/parse.rs
+++ b/crates/gamacros-workspace/src/v1/parse.rs
@@ -7,8 +7,8 @@ use gamacros_gamepad::Button;
 use crate::v1::profile::{ProfileV1ButtonRule, ProfileV1Stick};
 use crate::profile::{
     AppRules, ArrowsParams, Axis, ButtonAction, ButtonRule, ButtonRules,
-    ControllerSettings, ControllerSettingsMap, MouseParams, RuleMap, ScrollParams,
-    StepperParams, StickMode, StickRules, StickSide, Profile,
+    ControllerSettings, ControllerSettingsMap, Macros, MouseParams, Profile,
+    RuleMap, ScrollParams, StepperParams, StickMode, StickRules, StickSide,
 };
 use crate::ButtonChord;
 
@@ -203,12 +203,12 @@ fn parse_keystroke(input: &str) -> Result<KeyCombo, Error> {
     input.parse::<KeyCombo>().map_err(Error::KeyParse)
 }
 
-fn parse_macros(input: &[String]) -> Result<Vec<KeyCombo>, Error> {
+fn parse_macros(input: &[String]) -> Result<Macros, Error> {
     input
         .iter()
         .map(|m| m.as_str())
         .map(parse_keystroke)
-        .collect::<Result<Vec<_>, _>>()
+        .collect::<Result<Macros, _>>()
 }
 
 fn parse_stick_mode(raw: ProfileV1Stick) -> Result<StickMode, Error> {

--- a/crates/gamacrosd/Cargo.toml
+++ b/crates/gamacrosd/Cargo.toml
@@ -25,10 +25,11 @@ thiserror = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 lunchctl = { workspace = true }
-log = "0.4.26"
-colored = "3.0.0"
-fern = "0.6.1"
-ahash = "0.8"
+log = { workspace = true }
+colored = { workspace = true }
+fern = { workspace = true }
+ahash = { workspace = true }
+smallvec = { workspace = true }
 bitcode = "0.6.7"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/crates/gamacrosd/src/app/gamacros.rs
+++ b/crates/gamacrosd/src/app/gamacros.rs
@@ -7,7 +7,7 @@ use colored::Colorize;
 use gamacros_control::KeyCombo;
 use gamacros_bit_mask::Bitmask;
 use gamacros_gamepad::{Button, ControllerId, ControllerInfo, Axis as CtrlAxis};
-use gamacros_workspace::{ButtonAction, ControllerSettings, Profile, StickRules};
+use gamacros_workspace::{ButtonAction, ControllerSettings, Macros, Profile, StickRules};
 
 use crate::{app::ButtonPhase, print_debug, print_info};
 use super::stick::{StickProcessor, CompiledStickRules};
@@ -18,7 +18,7 @@ pub enum Action {
     KeyPress(KeyCombo),
     KeyRelease(KeyCombo),
     KeyTap(KeyCombo),
-    Macros(Arc<Vec<KeyCombo>>),
+    Macros(Arc<Macros>),
     Shell(String),
     MouseMove { dx: i32, dy: i32 },
     Scroll { h: i32, v: i32 },

--- a/crates/gamacrosd/src/logging.rs
+++ b/crates/gamacrosd/src/logging.rs
@@ -1,42 +1,88 @@
 // Colorized wrappers for logging
 
 use fern::Dispatch;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{OnceLock, RwLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use chrono::{Local, TimeZone};
 
 #[inline(always)]
 pub(crate) fn format_log(message: &str) -> String {
-    let now = chrono::Local::now().format("%Y.%m.%d %H:%M:%S").to_string();
+    let now = cached_now_string();
     format!("[{now}] {message}")
+}
+
+#[inline]
+fn cached_now_string() -> String {
+    static LAST_SECOND: AtomicU64 = AtomicU64::new(0);
+    static CACHED: OnceLock<RwLock<String>> = OnceLock::new();
+
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or_else(|_| 0);
+
+    let last = LAST_SECOND.load(Ordering::Acquire);
+    if last == secs {
+        // Fast path: reuse cached formatted timestamp
+        return CACHED
+            .get_or_init(|| RwLock::new(String::new()))
+            .read()
+            .expect("timestamp cache poisoned")
+            .clone();
+    }
+
+    // Slow path: format a new timestamp and update cache
+    let formatted = Local
+        .timestamp_opt(secs as i64, 0)
+        .single()
+        .map(|dt| dt.format("%Y.%m.%d %H:%M:%S").to_string())
+        .unwrap_or_else(|| String::from("0000.00.00 00:00:00"));
+
+    let lock = CACHED.get_or_init(|| RwLock::new(String::new()));
+    *lock.write().expect("timestamp cache poisoned") = formatted.clone();
+    LAST_SECOND.store(secs, Ordering::Release);
+    formatted
 }
 
 #[macro_export]
 macro_rules! print_error {
     ($($arg:tt)*) => {
-        let message = $crate::logging::format_log(&format!($($arg)*));
-        log::error!("{}", message.bright_red());
+        if log::log_enabled!(log::Level::Error) {
+            let __message = $crate::logging::format_log(&format!($($arg)*));
+            log::error!("{}", __message.bright_red());
+        }
     }
 }
 
 #[macro_export]
 macro_rules! print_info {
     ($($arg:tt)*) => {
-        let message = $crate::logging::format_log(&format!($($arg)*));
-        log::info!("{message}");
+        if log::log_enabled!(log::Level::Info) {
+            let __message = $crate::logging::format_log(&format!($($arg)*));
+            log::info!("{__message}");
+        }
     }
 }
 
 #[macro_export]
 macro_rules! print_debug {
     ($($arg:tt)*) => {
-        let message = $crate::logging::format_log(&format!($($arg)*));
-        log::debug!("{}", message.dimmed());
+        if log::log_enabled!(log::Level::Debug) {
+            let __message = $crate::logging::format_log(&format!($($arg)*));
+            log::debug!("{}", __message.dimmed());
+        }
     }
 }
 
 #[macro_export]
 macro_rules! print_warning {
     ($($arg:tt)*) => {
-        let message = $crate::logging::format_log(&format!($($arg)*));
-        log::info!("{}", message.bright_yellow());
+        if log::log_enabled!(log::Level::Info) {
+            let __message = $crate::logging::format_log(&format!($($arg)*));
+            log::info!("{}", __message.bright_yellow());
+        }
     }
 }
 

--- a/crates/gamacrosd/src/main.rs
+++ b/crates/gamacrosd/src/main.rs
@@ -295,9 +295,10 @@ fn run_event_loop(maybe_workspace_path: Option<PathBuf>) {
                 }
             }
             while let Ok(msg) = activity_std_rx.try_recv() {
-                if let ActivityEvent::DidActivateApplication(bundle_id) = msg {
-                    gamacros.set_active_app(&bundle_id)
-                }
+                let ActivityEvent::DidActivateApplication(bundle_id) = msg else {
+                    continue;
+                };
+                gamacros.set_active_app(&bundle_id);
             }
             let Some(workspace_rx) = maybe_workspace_rx.as_ref() else {
                 continue;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DualSense controller profile added with remapped triggers and preserved macro combo for L2+R2+L1.

* **Changes**
  * L2+R2 now copies a value to the clipboard.
  * Common profile: right stick = arrows, left stick = volume.
  * IDE/Browser profile: right stick = faster pointer movement, left stick = scroll.
  * Several button keystrokes simplified/removed; "A" now triggers Cmd+Shift+I+Q.

* **Chores**
  * Dependencies aligned to workspace-managed versions and a shared smallvec dependency added.

* **Performance**
  * Logging optimized with per-second timestamp caching and lazy message formatting to reduce overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->